### PR TITLE
Containerize envoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ The is a project on learning Envoy proxy with AI. Using AI as a tutor for Envoy 
 ## Tasks to complete
 - [ ] Run envoy in docker
   - [ ] Started envoy in a docker container. However, request to upstream failed with 503.  
+    - [X] Try out docker compose --> Works
+    - [X] Try to hit the local ip address
+    - [ ] Make docker containers using host network
 - [ ] Try out docker compose
 - [ ] Make env_setup.sh better
   - [ ] When container start failed, the script should throw error and stop. 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 The is a project on learning Envoy proxy with AI. Using AI as a tutor for Envoy proxy experiments. 
 
 ## Tasks to complete
-- [ ] Run envoy in docker
-  - [ ] Started envoy in a docker container. However, request to upstream failed with 503.  
+- [X] Run envoy in docker
+  - [X] Started envoy in a docker container. However, request to upstream failed with 503.  
     - [X] Try out docker compose --> Works
     - [X] Try to hit the local ip address
     - [ ] Make docker containers using host network
+      - Notes: 
+      `Linux-only feature: network_mode: "host" works only on Linux. On macOS and Windows, Docker Desktop uses a VM, and the host network mode does not behave the same way.`
 - [ ] Try out docker compose
 - [ ] Make env_setup.sh better
   - [ ] When container start failed, the script should throw error and stop. 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The is a project on learning Envoy proxy with AI. Using AI as a tutor for Envoy 
 
 ## Tasks to complete
 - [ ] Run envoy in docker
+  - [ ] Started envoy in a docker container. However, request to upstream failed with 503.  
 - [ ] Try out docker compose
 - [ ] Make env_setup.sh better
+  - [ ] When container start failed, the script should throw error and stop. 
 - [ ] Read the RouteMatch doc 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3'
+
+services:
+  nginx:
+    image: nginx
+    container_name: server-nginx
+    ports:
+      - "8081:80"
+
+  httpbin:
+    image: kennethreitz/httpbin
+    container_name: server-httpbin
+    ports:
+      - "8082:80"
+
+  echo:
+    image: ealen/echo-server
+    container_name: server-echo
+    ports:
+      - "8083:80"
+
+  python:
+    image: python:3-alpine
+    container_name: server-python
+    command: python -m http.server 80
+    ports:
+      - "8084:80"
+
+  envoy:
+    image: envoyproxy/envoy:v1.29-latest
+    container_name: envoy
+    volumes:
+      - ./envoy_routing_config.yml:/etc/envoy/envoy.yaml
+    ports:
+      - "10000:10000"
+      - "9901:9901"
+    depends_on:
+      - nginx
+      - httpbin
+      - echo
+      - python

--- a/env_setup.sh
+++ b/env_setup.sh
@@ -1,25 +1,33 @@
 #!/bin/bash
 
 # Usage: ./env_setup.sh [envoy_config_file]
-# Example: ./env_setup.sh my_envoy_config.yml
+# Example: ./env_setup.sh envoy_header_routing_config.yml
 
 # Set default Envoy config file if not provided
 ENVOY_CONFIG=${1:-envoy_routing_config.yml}
 
 # Stop and remove any existing containers
-docker rm -f server1 server2 server3 server4 2>/dev/null
+docker rm -f server1 server2 server3 server4 envoy 2>/dev/null
 
-# Run new containers
-docker run -d --name server1 -p 8081:80 nginx
-docker run -d --name server2 -p 8082:80 kennethreitz/httpbin
-docker run -d --name server3 -p 8083:80 ealen/echo-server
-docker run -d --name server4 -p 8084:8000 python:3-alpine sh -c "python -m http.server 8000"
+# Create a Docker network for all services
+docker network create envoy-net 2>/dev/null || true
 
-# Show running containers
-docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Ports}}"
+# Run service containers
+docker run -d --name server-nginx --network envoy-net -p 8081:80 nginx
+docker run -d --name server-httpbin --network envoy-net -p 8082:80 kennethreitz/httpbin
+docker run -d --name server-echo --network envoy-net -p 8083:80 ealen/echo-server
+docker run -d --name server-python --network envoy-net -p 8084:8000 python:3-alpine sh -c "python -m http.server 8000"
 
 # Start Envoy with the specified configuration
 echo "Starting Envoy with config file: $ENVOY_CONFIG"
-/usr/local/bin/envoy -c "$ENVOY_CONFIG" --log-level debug &
+docker run -d --name envoy \
+  --network envoy-net \
+  -v $(pwd)/$ENVOY_CONFIG:/etc/envoy/envoy.yaml \
+  -p 10000:10000 \
+  -p 9901:9901 \
+  envoyproxy/envoy:v1.29-latest
+
+# Show running containers
+docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Ports}}"
 
 echo "Environment setup complete. Containers and Envoy are running."

--- a/envoy_header_routing_config.yml
+++ b/envoy_header_routing_config.yml
@@ -60,7 +60,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-nginx
                 port_value: 8081
   - name: httpbin_service
     connect_timeout: 0.25s
@@ -73,7 +73,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-httpbin
                 port_value: 8082
   - name: echo_service
     connect_timeout: 0.25s
@@ -86,7 +86,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-echo
                 port_value: 8083
   - name: python_service
     connect_timeout: 0.25s
@@ -99,5 +99,5 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-python
                 port_value: 8084

--- a/envoy_routing_config.yml
+++ b/envoy_routing_config.yml
@@ -43,7 +43,7 @@ static_resources:
   clusters:
   - name: nginx_service
     connect_timeout: 0.25s
-    type: STATIC
+    type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: nginx_service
@@ -53,10 +53,10 @@ static_resources:
             address:
               socket_address:
                 address: server-nginx
-                port_value: 8081
+                port_value: 80
   - name: httpbin_service
     connect_timeout: 0.25s
-    type: STATIC
+    type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: httpbin_service
@@ -66,10 +66,10 @@ static_resources:
             address:
               socket_address:
                 address: server-httpbin
-                port_value: 8082
+                port_value: 80
   - name: echo_service
     connect_timeout: 0.25s
-    type: STATIC
+    type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: echo_service
@@ -79,10 +79,10 @@ static_resources:
             address:
               socket_address:
                 address: server-echo
-                port_value: 8083
+                port_value: 80
   - name: python_service
     connect_timeout: 0.25s
-    type: STATIC
+    type: STRICT_DNS
     lb_policy: ROUND_ROBIN
     load_assignment:
       cluster_name: python_service
@@ -92,4 +92,4 @@ static_resources:
             address:
               socket_address:
                 address: server-python
-                port_value: 8084
+                port_value: 80

--- a/envoy_routing_config.yml
+++ b/envoy_routing_config.yml
@@ -1,12 +1,12 @@
 admin:
   address:
-    socket_address: { address: 127.0.0.1, port_value: 9901 }
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
 
 static_resources:
   listeners:
   - name: listener_0
     address:
-      socket_address: { address: 127.0.0.1, port_value: 10000 }
+      socket_address: { address: 0.0.0.0, port_value: 10000 }
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager
@@ -52,7 +52,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-nginx
                 port_value: 8081
   - name: httpbin_service
     connect_timeout: 0.25s
@@ -65,7 +65,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-httpbin
                 port_value: 8082
   - name: echo_service
     connect_timeout: 0.25s
@@ -78,7 +78,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-echo
                 port_value: 8083
   - name: python_service
     connect_timeout: 0.25s
@@ -91,5 +91,5 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: 127.0.0.1
+                address: server-python
                 port_value: 8084

--- a/envoy_routing_dcompose.yml
+++ b/envoy_routing_dcompose.yml
@@ -1,0 +1,95 @@
+admin:
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 10000 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/nginx" }
+                route: 
+                  cluster: nginx_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/httpbin" }
+                route: 
+                  cluster: httpbin_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/echo" }
+                route: 
+                  cluster: echo_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/python" }
+                route: 
+                  cluster: python_service
+                  prefix_rewrite: "/"
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: nginx_service
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: nginx_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: server-nginx
+                port_value: 80
+  - name: httpbin_service
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: httpbin_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: server-httpbin
+                port_value: 80
+  - name: echo_service
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: echo_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: server-echo
+                port_value: 80
+  - name: python_service
+    connect_timeout: 0.25s
+    type: STRICT_DNS
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: python_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: server-python
+                port_value: 80

--- a/envoy_routing_localip.yml
+++ b/envoy_routing_localip.yml
@@ -1,0 +1,95 @@
+admin:
+  address:
+    socket_address: { address: 0.0.0.0, port_value: 9901 }
+
+static_resources:
+  listeners:
+  - name: listener_0
+    address:
+      socket_address: { address: 0.0.0.0, port_value: 10000 }
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: AUTO
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains: ["*"]
+              routes:
+              - match: { prefix: "/nginx" }
+                route: 
+                  cluster: nginx_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/httpbin" }
+                route: 
+                  cluster: httpbin_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/echo" }
+                route: 
+                  cluster: echo_service
+                  prefix_rewrite: "/"
+              - match: { prefix: "/python" }
+                route: 
+                  cluster: python_service
+                  prefix_rewrite: "/"
+          http_filters:
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: nginx_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: nginx_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 192.168.1.30
+                port_value: 8081
+  - name: httpbin_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: httpbin_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 192.168.1.30
+                port_value: 8082
+  - name: echo_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: echo_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 192.168.1.30
+                port_value: 8083
+  - name: python_service
+    connect_timeout: 0.25s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: python_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 192.168.1.30
+                port_value: 8084


### PR DESCRIPTION
Run Envoy in a Docker container with the following methods:
- Using docker compose, which will put all the contianers in the same sub network.
- Using local ip address. As docker containers has a port map from host network, try to hit the host ip and port for each backend container in the Envoy container. 